### PR TITLE
Prevent hhvm.hack.disallow_dynamic_var_env_funcs error in HHVM

### DIFF
--- a/lib/Table.php
+++ b/lib/Table.php
@@ -516,7 +516,7 @@ class Table
 			foreach (wrap_strings_in_arrays($definitions) as $definition)
 			{
 				$relationship = null;
-				$definition += compact('namespace');
+				$definition += array('namespace' => $namespace);
 
 				switch ($name)
 				{


### PR DESCRIPTION
When using PHP ActiveRecord with HHVM it yields a fatal error when interpreting model relationships:

```
Fatal error: (hhvm.hack.disallow_dynamic_var_env_funcs=error) compact should not be called dynamically in /vagrant/www/vendor/php-activerecord/php-activerecord/lib/Table.php
```

This PR fixes this error message.
